### PR TITLE
Remove deprecated public API fields

### DIFF
--- a/api/app/controllers/api/v2/base_controller.rb
+++ b/api/app/controllers/api/v2/base_controller.rb
@@ -18,7 +18,6 @@ module Api
       before_action :set_sentry_info
       before_action :limit_cursor_pagination, only: :index
       before_action :validate_order_params, only: :index
-      before_action :log_deprecated_order_field, only: :index
 
       after_action :verify_authorized, except: :not_found
       after_action :verify_policy_scoped, only: :index
@@ -182,20 +181,6 @@ module Api
         if params[:limit].to_i > MAX_CURSOR_PAGINATION_LIMIT
           render_error(status: :unprocessable_entity, message: "`limit` must be less than or equal to #{MAX_CURSOR_PAGINATION_LIMIT}.")
         end
-      end
-
-      # TODO: remove after confirming this field is no longer used.
-      # I don't think we ever documented it but I'm checking anyway.
-      def log_deprecated_order_field
-        return if params[:order].blank?
-
-        Sentry.capture_message(
-          "Request made with deprecated order field",
-          extra: {
-            oauth_application_id: current_oauth_application&.id,
-            order: params[:order],
-          },
-        )
       end
     end
   end

--- a/api/config/routes.rb
+++ b/api/config/routes.rb
@@ -642,11 +642,6 @@ Rails.application.routes.draw do
       resources :messages, only: [:create], module: :members
     end
 
-    # deprecated on 9/9/24; keeping until we've migrated all users w/ custom integrations
-    resources :projects, only: [:index]
-
-    # this must appear after :projects until projects are fully deprecated,
-    # otherwise the project route will clobber the channels route
     resources :channels, only: [:index], controller: "projects"
 
     resources :threads, only: [:create] do

--- a/api/test/controllers/api/v2/posts_controller_test.rb
+++ b/api/test/controllers/api/v2/posts_controller_test.rb
@@ -41,15 +41,6 @@ module Api
           assert_equal @posts[1].public_id, json_response["data"][0]["id"]
         end
 
-        test "sorts by recent activity (deprecated order object)" do
-          @posts.last.update(last_activity_at: 1.day.ago)
-
-          list_posts(params: { order: { by: "last_activity_at", direction: "desc" } })
-
-          assert_response :success
-          assert_equal @posts[1].public_id, json_response["data"][0]["id"]
-        end
-
         test "does not include posts in private projects" do
           private_project_post = create(:post, project: create(:project, :private, organization: @org), organization: @org)
 
@@ -63,7 +54,7 @@ module Api
           project = create(:project, organization: @org)
           create_list(:post, 3, project: project, organization: @org)
 
-          list_posts(params: { project_id: project.public_id })
+          list_posts(params: { channel_id: project.public_id })
 
           assert_response :success
           assert_equal 3, json_response["data"].count
@@ -82,7 +73,7 @@ module Api
         test "returns an error for a private project if the app is not a member of the project" do
           private_project = create(:project, :private, organization: @org)
 
-          list_posts(params: { project_id: private_project.public_id })
+          list_posts(params: { channel_id: private_project.public_id })
 
           assert_response :forbidden
         end
@@ -92,7 +83,7 @@ module Api
           private_project.add_oauth_application!(@org_oauth_app)
           create_list(:post, 3, project: private_project, organization: @org)
 
-          list_posts(params: { project_id: private_project.public_id })
+          list_posts(params: { channel_id: private_project.public_id })
 
           assert_response :success
           assert_equal 3, json_response["data"].count
@@ -158,16 +149,6 @@ module Api
           create_post(params: { content_markdown: "Test content" })
 
           assert_response :unprocessable_entity
-        end
-
-        test "works with deprecated project_id" do
-          html = "<p>Test content</p>"
-          StyledText.any_instance.expects(:markdown_to_html).returns(html)
-
-          create_post(params: { content_markdown: "Test content", project_id: @project.public_id })
-
-          assert_response :created
-          assert_equal @project.public_id, json_response.dig("channel", "id")
         end
 
         test "assigns the post to a member when using a user-scoped token" do


### PR DESCRIPTION
This PR removes deprecated field logging for public API endpoints, like the `/v2/projects` endpoint that was replaced with `/v2/channels` and the `order` object that was replaced with `sort` and `direction` fields.